### PR TITLE
ci: update CODEOWNERS with hyperledger-identus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hyperledger/identus-maintainers
+* @hyperledger-identus/identus-maintainers


### PR DESCRIPTION
Rename the group from `hyperledger` to `hyperledger-identus`