### PR TITLE
fix: JAVA_OPTS should not be set up by default (fix for #123)

### DIFF
--- a/identus-docker/docker-compose.yaml
+++ b/identus-docker/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
       - "8085:8085" # API endpoint
       - "8090:8090" # DIDComm endpoint
     environment:
-      JAVA_OPTS: "-XX:UseSVE=0"
       POLLUX_DB_HOST: db
       POLLUX_DB_PORT: 5432
       POLLUX_DB_NAME: pollux


### PR DESCRIPTION
Remove `JAVA_OPTS: "-XX:UseSVE=0"` from docker-compose.yaml Related with the workaround for identus-cloud-agent/1482 #101

Fix for #123